### PR TITLE
Fixed typo: bind.value -> binding.value

### DIFF
--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -56,7 +56,7 @@
                     handleListeners(el, binding.value, binding.oldValue);
                 },
                 unbind: function(el, binding){
-                    if(binding.value && typeof bind.value === 'function'){
+                    if(binding.value && typeof binding.value === 'function'){
                         if(el.removeEventListener){
                             el.removeEventListener('scroll', binding.value);
                         }else{


### PR DESCRIPTION
Fixed typo: bind.value -> binding.value