### PR TITLE
Fix issue: Vue is not loaded yet. Please make sure it is loaded before installing vue-scroll

### DIFF
--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -3,7 +3,7 @@
     var isVueLoaded = true;
 
     if(typeof require === 'undefined'){
-        Vue = Window.Vue;
+        Vue = window.Vue;
     }else{
         Vue = require('vue');
     }


### PR DESCRIPTION
I believe the problem is that Window is a typo and is always undefined by default, which causes the directive to warn "Vue is not loaded." The correct object that receives global variables is window (note the lowercase "W").