### PR TITLE
Optional throttle for called function

### DIFF
--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -25,27 +25,33 @@
 
                 var addListener = function(element, eventType, funcs){
                   var EVENT_SCROLL = 'scroll';
-                  var scrollData = {};
-                    
+
+                  //TODO decide if new object for each listener needed
                   // https://github.com/wangpin34/vue-scroll/issues/1
                   if((element === document.body || element === document || element === window) && eventType === SCROLL){
                     document.onscroll = function(e){
-                      scrollData.scrollTop = document.body.scrollTop;
-                      scrollData.scrollLeft = document.body.scrollLeft;
+	                  // creating new Object to disable reactivity
+                      var scrollData = {
+                        scrollTop: document.body.scrollTop,
+	                    scrollLeft: document.body.scrollLeft
+                      };
                       funcs.forEach(function(func){
-                        func && func(e, scrollData);
+                        func.called && func.called(e, scrollData);
                       })
                     }
                   }else {
                     var listener = function(e){
+                      // creating new Object to disable reactivity
+                      var scrollData = {};
                       e = e || window.event;
                       e.target = e.target || e.srcElement;
+
                       if(eventType === EVENT_SCROLL){
                         scrollData.scrollTop = element.scrollTop;
                         scrollData.scrollLeft = element.scrollLeft;
                       }
                       funcs.forEach(function(func){
-                        (typeof func !== 'undefined') && func(e, scrollData);
+                        (typeof func.called !== 'undefined') && func.called(e, scrollData);
                       })
                     }
                   
@@ -60,8 +66,28 @@
                   
                 if(typeof Q._initialized == 'undefined'){
                     
-                  Q.prototype.bind = (function(element, eventType, func){
-                    var funcs, i, length = elements.length;
+                  Q.prototype.bind = (function(element, eventType, func, arg){
+                    var funcs, i, length = elements.length, throttle;
+
+                    if(arg){
+                        var lastCallTimestamp, timeout = null, value, pos, caller = function(){
+                            timeout = null;
+                            lastCallTimestamp = Date.now();
+                            func(value, pos);
+                        };
+                        throttle = function(e, position){
+                            if(!lastCallTimestamp || Date.now() - lastCallTimestamp >= arg){
+                                lastCallTimestamp = Date.now();
+                                func(e, position);
+                            } else {
+                                value = e;
+                                pos = position;
+                                if(!timeout){
+                                    timeout = setTimeout(caller, arg);
+                                }
+                            }
+                        }
+                    }
 
                     for(i = 0; i < length; ++i){
                         if(elements[i] === element) break;
@@ -83,7 +109,10 @@
                       addListener(element, eventType, funcs[eventType]);
                     }
                     eventFuncs = funcs[eventType];
-                    eventFuncs.push(func);
+                    eventFuncs.push({
+                        original: func,
+                        called: throttle ? throttle : func
+                    });
 
                   }).bind(this);
 
@@ -104,11 +133,11 @@
                     length = funcs.length;
                     var eventFuncs = funcs[eventType];
                     for(i = 0; i < length; ++i){
-                        if(eventFuncs[i] === func) break;
+                        if(eventFuncs[i].original === func) break;
                     }
 
                     if(!funcs[eventType] || i >= length){
-                      console.warn('There are no listener could be removed.');
+                      console.warn('1There are no listener could be removed.');
                       return;
                     }
                     eventFuncs.splice(eventFuncs[i], 1);
@@ -126,7 +155,10 @@
                     if(!binding.value || typeof binding.value !== 'function'){
                         throw new Error('The scroll listener is not a function');
                     }
-                    q.bind(el, EVENT_SCROLL, binding.value);
+	                if(binding.arg && isNaN(binding.arg)){
+		                throw new Error('Throttle delay is not a number')
+	                }
+	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg);
                 },
                 inserted: function(el, binding){
                     //To do, check whether element is scrollable and give warn message when not
@@ -138,7 +170,10 @@
                     if(!binding.value || typeof binding.value !== 'function'){
                         throw new Error('The scroll listener is not a function');
                     }
-                    q.bind(el, EVENT_SCROLL, binding.value);
+	                if(binding.arg && isNaN(binding.arg)){
+		                throw new Error('Throttle delay is not a number')
+	                }
+	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg);
                     q.unbind(el, EVENT_SCROLL, binding.oldValue);
                 },
                 unbind: function(el, binding){

--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -61,14 +61,18 @@
                 if(typeof Q._initialized == 'undefined'){
                     
                   Q.prototype.bind = (function(element, eventType, func){
-                    var funcs;
-                    
-                    if(elements.indexOf(element) < 0){
+                    var funcs, i, length = elements.length;
+
+                    for(i = 0; i < length; ++i){
+                        if(elements[i] === element) break;
+                    }
+
+                    if(i >= length){
                       elements.push(element);
                       listeners.push({});
-                      funcs = listeners[listeners.length - 1];
+                      funcs = listeners[length];
                     }else{
-                      funcs = listeners[elements.indexOf(element)];
+                      funcs = listeners[i];
                     }
 
                     var eventFuncs;
@@ -84,21 +88,30 @@
                   }).bind(this);
 
                   Q.prototype.unbind = (function(element, eventType, func){
-                    var funcs;
+                    var funcs, length = elements.length, i;
+
+	                  for(i = 0; i < length; ++i){
+		                  if(elements[i] === element) break;
+	                  }
                     
-                    if(elements.indexOf(element) < 0){
+                    if(i >= length){
                       console.warn('There are no listener could be removed.');
                       return 1;
                     }else{
-                      funcs = listeners[elements.indexOf(element)];
+                      funcs = listeners[i];
                     }
 
-                    var eventFuncs;
-                    if(!funcs[eventType] || (eventFuncs = funcs[eventType]).indexOf(func) < 0){
+                    length = funcs.length;
+                    var eventFuncs = funcs[eventType];
+                    for(i = 0; i < length; ++i){
+                        if(eventFuncs[i] === func) break;
+                    }
+
+                    if(!funcs[eventType] || i >= length){
                       console.warn('There are no listener could be removed.');
                       return;
                     }
-                    eventFuncs.splice(eventFuncs.indexOf(func), 1);
+                    eventFuncs.splice(eventFuncs[i], 1);
                     console.log('A event listener is removed successfully');
                   }).bind(this);
 


### PR DESCRIPTION
Perfomance was improved by adding optional throttle function #16     

[indexOf](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) changed to simple for loop because indexOf unavaliable on IE 8 and lower, can be slower than for loop in some browsers and cannot perform search by object fields.    

Unexpected behavior connected with Vue [reactivity](https://vuejs.org/v2/guide/reactivity.html) removed -  new object now created in each listener call.    
Maybe we shoud create new object for each called function too