### PR TITLE
New object for each listener and debounce function enhancements 

### DIFF
--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -26,34 +26,31 @@
                 var addListener = function(element, eventType, funcs){
                   var EVENT_SCROLL = 'scroll';
 
-                  //TODO decide if new object for each listener needed
                   // https://github.com/wangpin34/vue-scroll/issues/1
                   if((element === document.body || element === document || element === window) && eventType === SCROLL){
                     document.onscroll = function(e){
-	                  // creating new Object to disable reactivity
-                      var scrollData = {
-                        scrollTop: document.body.scrollTop,
-	                    scrollLeft: document.body.scrollLeft
-                      };
+
                       funcs.forEach(function(func){
-                        func.called && func.called(e, scrollData);
+                        func.called && func.called(e, {
+	                        scrollTop: document.body.scrollTop,
+	                        scrollLeft: document.body.scrollLeft
+                        });
                       })
                     }
                   }else {
                     var listener = function(e){
-                      // creating new Object to disable reactivity
-                      var scrollData = {};
                       e = e || window.event;
                       e.target = e.target || e.srcElement;
 
-                      if(eventType === EVENT_SCROLL){
-                        scrollData.scrollTop = element.scrollTop;
-                        scrollData.scrollLeft = element.scrollLeft;
-                      }
                       funcs.forEach(function(func){
+	                    var scrollData = {};
+	                    if(eventType === EVENT_SCROLL){
+	                        scrollData.scrollTop = element.scrollTop;
+	                        scrollData.scrollLeft = element.scrollLeft;
+	                    }
                         (typeof func.called !== 'undefined') && func.called(e, scrollData);
                       })
-                    }
+                    };
                   
                     if(element.addEventListener){
                       element.addEventListener(eventType, listener);
@@ -70,7 +67,8 @@
                     var funcs, i, length = elements.length, throttle;
 
                     if(arg){
-                        var lastCallTimestamp, timeout = null, value, pos, caller = function(){
+                        var lastCallTimestamp, timeout = null, value, pos;
+                        var caller = function(){
                             timeout = null;
                             lastCallTimestamp = Date.now();
                             func(value, pos);

--- a/lib/vue-scroll.js
+++ b/lib/vue-scroll.js
@@ -62,9 +62,9 @@
                 }
                   
                 if(typeof Q._initialized == 'undefined'){
-                    
-                  Q.prototype.bind = (function(element, eventType, func, arg){
-                    var funcs, i, length = elements.length, throttle;
+
+                  Q.prototype.bind = (function(element, eventType, func, arg, type){
+                    var funcs, i, length = elements.length, called;
 
                     if(arg){
                         var lastCallTimestamp, timeout = null, value, pos;
@@ -73,17 +73,26 @@
                             lastCallTimestamp = Date.now();
                             func(value, pos);
                         };
-                        throttle = function(e, position){
-                            if(!lastCallTimestamp || Date.now() - lastCallTimestamp >= arg){
-                                lastCallTimestamp = Date.now();
-                                func(e, position);
-                            } else {
+                        if(type && type.debounce === true){
+                            called = function(e, position){
+                                clearTimeout(timeout);
                                 value = e;
                                 pos = position;
-                                if(!timeout){
-                                    timeout = setTimeout(caller, arg);
-                                }
+                                timeout = setTimeout(caller, arg);
                             }
+                        } else {
+	                        called = function(e, position){
+		                        if(!lastCallTimestamp || Date.now() - lastCallTimestamp >= arg){
+			                        lastCallTimestamp = Date.now();
+			                        func(e, position);
+		                        } else {
+			                        value = e;
+			                        pos = position;
+			                        if(!timeout){
+				                        timeout = setTimeout(caller, arg);
+			                        }
+		                        }
+	                        }
                         }
                     }
 
@@ -109,7 +118,7 @@
                     eventFuncs = funcs[eventType];
                     eventFuncs.push({
                         original: func,
-                        called: throttle ? throttle : func
+                        called: called ? called : func
                     });
 
                   }).bind(this);
@@ -154,9 +163,9 @@
                         throw new Error('The scroll listener is not a function');
                     }
 	                if(binding.arg && isNaN(binding.arg)){
-		                throw new Error('Throttle delay is not a number')
+		                throw new Error('Delay argument is not a number');
 	                }
-	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg);
+	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg, binding.modifiers);
                 },
                 inserted: function(el, binding){
                     //To do, check whether element is scrollable and give warn message when not
@@ -169,9 +178,9 @@
                         throw new Error('The scroll listener is not a function');
                     }
 	                if(binding.arg && isNaN(binding.arg)){
-		                throw new Error('Throttle delay is not a number')
+		                throw new Error('Delay argument is not a number');
 	                }
-	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg);
+	                q.bind(el, EVENT_SCROLL, binding.value, binding.arg, binding.modifiers);
                     q.unbind(el, EVENT_SCROLL, binding.oldValue);
                 },
                 unbind: function(el, binding){


### PR DESCRIPTION
As mentioned in #17 caller function moved to new line to make it more readable.    
For each listener in <b>funcs</b> array new Object is created.    
[Modifiers](https://vuejs.org/v2/guide/custom-directive.html#Directive-Hook-Arguments) field from <b>binding</b> object added as optional argument for bind function. Now user can use directive like this:
`v-scroll:300.debounce`    
And debounce function instead of throttle will be used to call original func.    
To make code more readable you can pass whole `binding` object to <b>bind</b> function or pass arguments to directive like this:
`v-scroll="{function: func, wrapper: 'debounce', delay: 50}"`
It's up to you to decide which one will be better